### PR TITLE
add build GH Action workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+on: 
+  repository_dispatch:
+    types: [tests-report]
+  push:
+jobs:
+  tests:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - name: Build src
+        run: cargo build


### PR DESCRIPTION
Adds a GH Action that runs `cargo build`. 

This allows this repo to be remotely build-test triggered by the cronned repo tester for near-examples.  

